### PR TITLE
Always use the integize helper in place of to_i

### DIFF
--- a/lib/google_drive/network_metrics.rb
+++ b/lib/google_drive/network_metrics.rb
@@ -36,23 +36,23 @@ class NetworkMetrics
       end
     else
       {
-        total:   metrics_cell("Active Reach", year, Proc.new {|x| x.to_i}) + 
-                 metrics_cell("Passive Reach", year, Proc.new {|x| x.to_i}),
+        total:   metrics_cell("Active Reach", year, Proc.new { |x| integize(x) }) +
+                 metrics_cell("Passive Reach", year, Proc.new { |x| integize(x) }),
         breakdown: {
-          active:  metrics_cell("Active Reach", year, Proc.new {|x| x.to_i}),
-          passive: metrics_cell("Passive Reach", year, Proc.new {|x| x.to_i}),
+          active:  metrics_cell("Active Reach", year, Proc.new { |x| integize(x) }),
+          passive: metrics_cell("Passive Reach", year, Proc.new { |x| integize(x) }),
         }
       }
     end
   end
 
   def self.pr_pieces(year)
-    block = Proc.new { |x| x.to_i }
+    block = Proc.new { |x| integize(x) }
     metrics_cell('PR Pieces', year, block)
   end
 
   def self.events_hosted(year)
-    block = Proc.new { |x| x.to_i }
+    block = Proc.new { |x| integize(x) }
     metrics_cell('Events hosted', year, block)
   end
 
@@ -62,7 +62,7 @@ class NetworkMetrics
         memo += trained[:total]
       end
     else
-      block = Proc.new { |x| x.to_i }
+      block = Proc.new { |x| integize(x) }
       h     = {
           commercial:     'Commercial people trained',
           non_commercial: 'Non-commercial people trained'
@@ -78,7 +78,7 @@ class NetworkMetrics
   end
 
   def self.network_size(year, month)
-    block = Proc.new { |x| x.to_i }
+    block = Proc.new { |x| integize(x) }
     if year.nil? && month.nil?
       years.inject(0) do |memo, year|
         memo += metrics_cell('Network size', year, block)

--- a/lib/helpers/metrics_helper.rb
+++ b/lib/helpers/metrics_helper.rb
@@ -20,7 +20,7 @@ module MetricsHelper
 
   def integize(cell)
     if cell.class == String
-      cell.gsub(/[^\d|\.]/, '').to_i
+      cell.gsub(/[^\d\.\-]/, '').to_i
     else
       cell.to_i
     end

--- a/spec/libs/network_metrics_spec.rb
+++ b/spec/libs/network_metrics_spec.rb
@@ -24,20 +24,20 @@ describe NetworkMetrics do
 
   it "should show the correct cumulative reach", :vcr do
     NetworkMetrics.reach.should == {
-      :total   => 542050,
+      :total   => 845144,
       :breakdown => {
-        :active  => 13790,
-        :passive => 528260,
+        :active  => 24306,
+        :passive => 820838,
       }
     }
   end
 
   it "should show the correct reach for 2013", :vcr do
     NetworkMetrics.reach(2013).should == {
-      :total   => 302,
+      :total   => 303396,
       :breakdown => {
-        :active  => 10,
-        :passive => 292,
+        :active  => 10526,
+        :passive => 292870,
       }
     }
   end


### PR DESCRIPTION
The ensures strings fetched from the google drive API are decommified before being converted to integers.

Fixes #20.
