### PR TITLE
Make 2015 total costs more consistent with 2015

### DIFF
--- a/lib/google_drive/financial_metrics.rb
+++ b/lib/google_drive/financial_metrics.rb
@@ -169,7 +169,15 @@ class FinancialMetrics
         staff:      'Staff costs',
         other:      'Other costs',
       }
-      extract_metrics h, year, month, block
+      breakdown = extract_metrics h, year, month, block
+
+      data = [:actual, :annual_target, :ytd_target].inject({}) do |d, v|
+        d[v] = breakdown.inject(0.0) do |sum, (_, t)|
+          sum += t[v]
+        end
+        d
+      end
+      data.merge({ breakdown: breakdown })
     end
   end
 

--- a/spec/libs/financial_metrics_spec.rb
+++ b/spec/libs/financial_metrics_spec.rb
@@ -272,31 +272,36 @@ describe FinancialMetrics do
     }
 
     FinancialMetrics.total_costs(2015, 2).should == {
-      :network => {
-        :actual => 81000.0,
-        :annual_target => 1195000.0,
-        :ytd_target => 139000.0,
-      },
-      :innovation => {
-        :actual => 173000.0,
-        :annual_target => 1891000.0,
-        :ytd_target => 297000.0,
-      },
-      :core => {
-        :actual => 80000.0,
-        :annual_target => 936000.0,
-        :ytd_target => 125000.0,
-      },
-      :staff => {
-        :actual => 201000.0,
-        :annual_target => 1230000.0,
-        :ytd_target => 194000.0,
-      },
-      :other => {
-        :actual => 124000.0,
-        :annual_target => 1000000.0,
-        :ytd_target => 144000.0,
-      },
+      :actual => 659000.0,
+      :annual_target => 6252000.0,
+      :ytd_target => 899000.0,
+      :breakdown => {
+        :network => {
+          :actual => 81000.0,
+          :annual_target => 1195000.0,
+          :ytd_target => 139000.0,
+        },
+        :innovation => {
+          :actual => 173000.0,
+          :annual_target => 1891000.0,
+          :ytd_target => 297000.0,
+        },
+        :core => {
+          :actual => 80000.0,
+          :annual_target => 936000.0,
+          :ytd_target => 125000.0,
+        },
+        :staff => {
+          :actual => 201000.0,
+          :annual_target => 1230000.0,
+          :ytd_target => 194000.0,
+        },
+        :other => {
+          :actual => 124000.0,
+          :annual_target => 1000000.0,
+          :ytd_target => 144000.0,
+        }
+      }
     }
   end
 


### PR DESCRIPTION
Summing breakdown figures makes life a bit easier at the other end, and
makes the structure of total costs for 2015 match the previous
structure.
